### PR TITLE
Bump pydantic-monty minimum to >=0.0.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
     "dspy>=3.0",
-    "pydantic-monty>=0.0.5",
+    "pydantic-monty>=0.0.7",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
v0.0.7 adds map() with user-defined functions, sorted(key=...) support,
and other builtins that LLM-generated code commonly uses.

https://claude.ai/code/session_011KdmcyYg33oBPo6RJFzRri